### PR TITLE
Add more context to the console output during the build

### DIFF
--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -369,12 +369,12 @@ export const build = async (contractPath: string) => {
 	// Compile contract at path
 	await compileContract(contractPath);
 	// Generate Typescript definitions for contract
-	spinner.create(`Generating type definitions`);
+	spinner.create(`Generating type definitions:` + contractPath);
 	try {
 		await generateTypes(pathToIdentifier(contractPath));
-		spinner.end(`Generated type definitions`);
+		spinner.end(`Generated type definitions: ` + contractPath);
 	} catch (error) {
-		spinner.fail(`Failed to generate type definitions`);
+		spinner.fail(`Failed to generate type definitions: ` + contractPath);
 		console.log(` --> ${error.message}`);
 	}
 };
@@ -396,7 +396,7 @@ export const outputPathForContract = (contractPath: string) =>
  */
 export const compileContract = async (contractPath: string) => {
 	// Begin logs
-	spinner.create(`Compiling contract`);
+	spinner.create(`Compiling contract: ` + contractPath);
 
 	const basename = path.basename(contractPath, '.cpp');
 
@@ -428,5 +428,5 @@ export const compileContract = async (contractPath: string) => {
 			throw err;
 		});
 	// Notify build task completed
-	spinner.end(`Compiled contract`);
+	spinner.end(`Compiled contract output into folder: ` + outputPath);
 };


### PR DESCRIPTION
_This is a small PR to dip my toe in the water for contributing to an NPM project. I have a few more changes coming through using the lamington code locally on my projects for which I will open separate PRs so as to provide more atomic changes into the project if you guys see them to be valuable changes._

---
When building Lamington on a project with multiple contracts it is difficult to know which contracts are being built during the build/type generation steps and therefore which if any files should be excluded in the `.lamingtonrc` file to help speed up the build process.

This change adds more details of which cpp files are being built and which are being type generated to help with this problem and where the output files are being placed.
