### PR TITLE
Adds an assertion `assertEOSErrorIncludesMessage` 

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -139,15 +139,15 @@ const assertExpectedEOSError = async (
 				`Expected ${eosErrorName}, got ${error.json.error.name} instead.`
 			);
 			if (furtherErrorCheck) {
-				furtherErrorCheck(error)
-			};
+				furtherErrorCheck(error);
+			}
 		} else {
 			// Fail if error not thrown by EOS
 			assert.fail(
 				`Expected EOS error ${eosErrorName}, but got ${JSON.stringify(error, null, 4)} instead.`
 			);
 		}
-		return true
+		return true;
 	}
 	return false;
 };
@@ -164,7 +164,7 @@ export const assertEOSError = async (
 	eosErrorName: string,
 	description: string
 ) => {
-	if (assertExpectedEOSError(operation, eosErrorName, (_) => {})) {
+	if (assertExpectedEOSError(operation, eosErrorName, _ => {})) {
 		// Execute operation and handle exceptions
 		assert.fail(`Expected ${description} but operation completed successfully.`);
 	}
@@ -183,7 +183,7 @@ export const assertEOSErrorIncludesMessage = async (operation: Promise<any>, mes
 	console.log('should get here for the error' + message);
 
 	if (
-		!(await assertExpectedEOSError(operation, eosErrorName, (error)  => {
+		!(await assertExpectedEOSError(operation, eosErrorName, error => {
 			let errorMessage = error.json.error.details[0].message;
 			console.log('should get here before error meassge chack: ' + JSON.stringify(error));
 
@@ -197,8 +197,8 @@ export const assertEOSErrorIncludesMessage = async (operation: Promise<any>, mes
 				`Expected to include ${message}, got ${errorMessage} instead.`
 			);
 			console.log('should not get here');
-		})
-	)) {
+		}))
+	) {
 		// Fail if no exception thrown
 		assert.fail(
 			`Expected ${eosErrorName} with message to include ${message} but operation completed successfully.`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -164,7 +164,7 @@ export const assertEOSError = async (
 	eosErrorName: string,
 	description: string
 ) => {
-	if (assertExpectedEOSError(operation, eosErrorName, _ => {})) {
+	if (assertExpectedEOSError(operation, eosErrorName)) {
 		// Execute operation and handle exceptions
 		assert.fail(`Expected ${description} but operation completed successfully.`);
 	}
@@ -180,12 +180,9 @@ export const assertEOSError = async (
 export const assertEOSErrorIncludesMessage = async (operation: Promise<any>, message: string) => {
 	const eosErrorName = 'eosio_assert_message_exception';
 	// Execute operation and handle exceptions
-	console.log('should get here for the error' + message);
-
 	if (
 		!(await assertExpectedEOSError(operation, eosErrorName, error => {
 			let errorMessage = error.json.error.details[0].message;
-			console.log('should get here before error meassge chack: ' + JSON.stringify(error));
 
 			if (!errorMessage) {
 				assert.fail(
@@ -196,7 +193,6 @@ export const assertEOSErrorIncludesMessage = async (operation: Promise<any>, mes
 				errorMessage.includes(message),
 				`Expected to include ${message}, got ${errorMessage} instead.`
 			);
-			console.log('should not get here');
 		}))
 	) {
 		// Fail if no exception thrown

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -146,6 +146,42 @@ export const assertEOSError = async (
 };
 
 /**
+ * Asserts EOS throws an error and validates the error output name matches the
+ * expected 'eosio_assert_message_exception' and the error message includes `description`
+ * @author Dallas Johnson <github.com/dallasjohnson>
+ * @param operation Operation promise
+ * @param description Output message description
+ */
+export const assertEOSErrorIncludesMessage = async (operation: Promise<any>, message: string) => {
+	const eosErrorName = 'eosio_assert_message_exception';
+	// Execute operation and handle exceptions
+	try {
+		await operation;
+	} catch (error) {
+		let errorMessage = error.json.error.details[0].message;
+		if (error.json && error.json.error && error.json.error.name && errorMessage) {
+			// Compare error and fail if the error doesn't match the expected
+			assert(
+				error.json.error.name === eosErrorName,
+				`Expected ${eosErrorName}, got ${error.json.error.name} instead.`
+			);
+			assert(
+				errorMessage.includes(message),
+				`Expected to include ${message}, got ${errorMessage} instead.`
+			);
+			return;
+		} else {
+			// Fail if error not thrown by EOS
+			assert.fail(
+				`Expected EOS error ${eosErrorName}, but got ${JSON.stringify(error, null, 4)} instead.`
+			);
+		}
+	}
+	// Fail if no exception thrown
+	assert.fail(`Expected ${eosErrorName} but operation completed successfully.`);
+};
+
+/**
  * Asserts operation throws an `eosio_assert_message_exception` error
  * @author Kevin Brown <github.com/thekevinbrown>
  * @param operation Operation promise


### PR DESCRIPTION
This should assert the error message for an expected `eosio_assert_message_exception` includes the given description message.

* The purpose of this is to allow more thorough testing of expected errors and ensure that one error is not masked by another error and potentially leaving logical branches of code untested. 
* It is also intended to check the error message is included by the thrown error message rather than equals which allows for as error message to be safely changed in the contract while maintaining a constant key (possibly a localised key used by a client.)

eg. A contract may include:

    check(existing == statstable.end(), "ERR::CREATE_EXISITNG_SYMBOL::token with symbol already exists");

 and a safe test assertion may only check for the `ERR::CREATE_EXISITNG_SYMBOL` part which allows for the contract developer to safely evolve the error message for debugging purposes without breaking the tests.