### PR TITLE
Add `skip-build` option to the cli

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,7 +11,7 @@ program
 	.command('build [contract_path]', 'build all smart contracts')
 	.command('start', 'start the eos blockchain in docker')
 	.command('stop', 'stop the eos blockchain in docker')
-	.command('test', 'run your unit / integration tests')
+	.command('test [skip-build]', 'run your unit / integration tests')
 	.on('*', () => {
 		console.log('Unknown Command: ' + program.args.join(' '));
 		program.help();

--- a/src/cli/lamington-test.ts
+++ b/src/cli/lamington-test.ts
@@ -11,6 +11,9 @@ import { ConfigManager } from '../configManager';
 const run = async () => {
 	// Initialize the configuration
 	await ConfigManager.initWithDefaults();
+	const args = process.argv;
+
+	console.log('args: ' + args);
 
 	// Stop running instances for fresh test environment
 	if (await eosIsReady()) {
@@ -22,7 +25,9 @@ const run = async () => {
 		await startEos();
 	}
 	// Start compiling smart contracts
+	if (!args.includes('skip-build')) {
 	await buildAll();
+	}
 	// Begin running tests
 	await runTests();
 	// Stop EOSIO instance if keepAlive is false


### PR DESCRIPTION
To improve the testing loop adding this option to the Lamington CLI could enable the dev to quickly iterate on writing and running tests without having to re-compile the contracts and type definitions each time.

By running the tests with the command  such as `npm run-script test  skip-build` the contract and type generated files steps would be skipped and therefore only running the docker setup and test execution.