### PR TITLE
Adds `auths` option to the options parameter when calling a contract action

### DIFF
--- a/src/contracts/typeGenerator.ts
+++ b/src/contracts/typeGenerator.ts
@@ -75,7 +75,11 @@ export const generateTypes = async (contractIdentifier: string) => {
 		'',
 	];
 	// Define imports
-	const imports = ['Account', 'Contract', 'GetTableRowsOptions'];
+	const imports = [
+		'Account',
+		'Contract',
+		'GetTableRowsOptions',
+	];
 	if (contractTables.length > 0) imports.push('TableRowsResult');
 	// Generate import definitions
 	result.push(`import { ${imports.join(', ')} } from 'lamington';`);
@@ -99,7 +103,7 @@ export const generateTypes = async (contractIdentifier: string) => {
 			(parameter: any) => `${parameter.name}: ${mapParameterType(parameter.type)}`
 		);
 		// Optional parameter at the end on every contract method.
-		parameters.push('options?: { from?: Account }');
+		parameters.push('options?: { from?: Account, auths?: ActorPermission[] }');
 
 		return `${action.name}(${parameters.join(', ')}): Promise<any>;`;
 	});


### PR DESCRIPTION
In order to specify permissions beyond `actor@active` more granular permissions options are needed which can be provided this via the `auths` parameter.

This adds the ability to still call an action with the current syntax:
    `{from: actor}`
 which will populate the action with the `actor@active` permission but also add the ability to provide more granular permission options with an option like:
    `{ auths: [{ actor: "myactor", permission: "transfer"}, {actor: "myfriend", permission: "cosign"}]` 

This allows for more flexibility while still being able to exercise best contract action security practices of the minimal permissions required to perform an action.