### PR TITLE
Create typescript type defs

### DIFF
--- a/src/cli/lamington-test.ts
+++ b/src/cli/lamington-test.ts
@@ -26,7 +26,7 @@ const run = async () => {
 	}
 	// Start compiling smart contracts
 	if (!args.includes('skip-build')) {
-	await buildAll();
+		await buildAll();
 	}
 	// Begin running tests
 	await runTests();

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -94,24 +94,21 @@ export const buildImage = async () => {
 	await rimraf(TEMP_DOCKER_DIRECTORY);
 	await mkdirp(TEMP_DOCKER_DIRECTORY);
 	// Write a Dockerfile so Docker knows what to build.
-	const systemDeps = [
-		'build-essential',
-		'ca-certificates',
-		'cmake',
-		'curl',
-		'git',
-		'wget',
-	]
+	const systemDeps = ['build-essential', 'ca-certificates', 'cmake', 'curl', 'git', 'wget'];
 	await writeFile(
 		path.join(TEMP_DOCKER_DIRECTORY, 'Dockerfile'),
 		`
 		FROM ubuntu:18.04
 
-		RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends ${systemDeps.join(' ')}
+		RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends ${systemDeps.join(
+			' '
+		)}
 		RUN wget ${ConfigManager.cdt} && apt-get install -y ./*.deb && rm -f *.deb
 		RUN wget ${ConfigManager.eos} && apt-get install -y ./*.deb && rm -f *.deb
 		RUN eos_ver=$(ls /usr/opt/eosio | head -n 1); \
-			git clone --depth 1 --branch ${ConfigManager.contracts} https://github.com/EOSIO/eosio.contracts.git /usr/opt/eosio.contracts &&\
+			git clone --depth 1 --branch ${
+				ConfigManager.contracts
+			} https://github.com/EOSIO/eosio.contracts.git /usr/opt/eosio.contracts &&\
 			cd /usr/opt/eosio.contracts && ./build.sh -e "/usr/opt/eosio/$eos_ver" -c /usr/opt/eosio.cdt
 		RUN apt-get clean && rm -rf /tmp/* /var/tmp/* && rm -rf /var/lib/apt/lists/*
 		`.replace(/\t/gm, '')

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -48,10 +48,10 @@ export enum LamingtonDebugLevel {
  * values by specifying them in their `.lamingtonrc`
  */
 const DEFAULT_CONFIG = {
-	eos:'',
-	cdt:'',
-	contracts:'v1.8.0-rc1',
-	debug:LamingtonDebugLevel.NONE,
+	eos: '',
+	cdt: '',
+	contracts: 'v1.8.0-rc1',
+	debug: LamingtonDebugLevel.NONE,
 	debugTransactions: false,
 	keepAlive: false,
 	outDir: CACHE_DIRECTORY,
@@ -117,7 +117,7 @@ export class ConfigManager {
 		return asset.browser_download_url as string;
 	}
 
-	public static async isValidConfig(config:object) {
+	public static async isValidConfig(config: object) {
 		return true;
 	}
 
@@ -129,7 +129,11 @@ export class ConfigManager {
 	 */
 	public static async createConfigIfMissing(atPath = CONFIGURATION_FILE_NAME) {
 		// Prevent overwriting existing configuration when valid
-		if (await ConfigManager.configExists(atPath) && await ConfigManager.isValidConfig(ConfigManager.config)) return;
+		if (
+			(await ConfigManager.configExists(atPath)) &&
+			(await ConfigManager.isValidConfig(ConfigManager.config))
+		)
+			return;
 		// Create the config directory
 		await mkdirp(CACHE_DIRECTORY);
 		// Fetch the latest repository configuration

--- a/src/contracts/contract.ts
+++ b/src/contracts/contract.ts
@@ -116,7 +116,7 @@ export class Contract implements EOSJSContract {
 					if (options.from && options.from instanceof Account) {
 						authorization = options.from.active;
 
-				// Ensure we have the key to sign with.
+						// Ensure we have the key to sign with.
 						EOSManager.addSigningAccountIfMissing(options.from);
 					} else if (options.auths && options.auths instanceof Array) {
 						authorization = options.auths;

--- a/src/contracts/typeGenerator.test.ts
+++ b/src/contracts/typeGenerator.test.ts
@@ -5,7 +5,7 @@ import { eosIsReady, startEos, buildAll, stopContainer } from '../cli/utils';
 import { mapParameterType } from './typeGenerator';
 
 /**
- * Javascript only supports number, so CPP integer types need to be mapped accordingly
+ * Javascript only supports 64 bit floating point numbers natively, so CPP integer types need to be mapped accordingly
  */
 const numberTypes = [
 	'int8',
@@ -43,27 +43,31 @@ const stringNumberTypes = [
 describe('type generator', function() {
 	context('map parameter types', function() {
 		it(`should map 'string' to 'string'`, function() {
-			assert.equal(mapParameterType('string'), 'string', `'string' types should map to 'string'`);
+			assert.equal(
+				mapParameterType({ eosType: 'string' }),
+				'string',
+				`'string' types should map to 'string'`
+			);
 		});
 
 		it(`should map 'bool' to 'boolean'`, function() {
-			assert.equal(mapParameterType('bool'), 'boolean');
+			assert.equal(mapParameterType({ eosType: 'bool' }), 'boolean');
 		});
 
 		context('eos types', function() {
 			it(`should map name types to 'string|number'`, function() {
-				stringNumberTypes.map(type =>
+				stringNumberTypes.map(eosType =>
 					assert.equal(
-						mapParameterType(type),
+						mapParameterType({ eosType }),
 						'string|number',
-						`'${type}' type should map to 'string' or 'number'`
+						`'${eosType}' type should map to 'string' or 'number'`
 					)
 				);
 			});
 
 			it(`should map 'checksum' to 'string'`, function() {
 				assert.equal(
-					mapParameterType('checksum'),
+					mapParameterType({ eosType: 'checksum' }),
 					'string',
 					`'checksum' type should map to 'string'`
 				);
@@ -71,12 +75,12 @@ describe('type generator', function() {
 		});
 
 		context('big numbers', function() {
-			numberTypes.forEach(type => {
-				it(`should map '${type}' to 'number'`, function() {
+			numberTypes.forEach(eosType => {
+				it(`should map '${eosType}' to 'number'`, function() {
 					assert.equal(
-						mapParameterType(type),
+						mapParameterType({ eosType }),
 						'number',
-						`Integer type '${type}' should map to 'number'`
+						`Integer type '${eosType}' should map to 'number'`
 					);
 				});
 			});
@@ -84,11 +88,11 @@ describe('type generator', function() {
 
 		context('complex types', function() {
 			it(`should handle array types`, function() {
-				assert.equal(mapParameterType('bool[]'), 'Array<boolean>');
+				assert.equal(mapParameterType({ eosType: 'bool[]' }), 'Array<boolean>');
 			});
 
 			xit(`should handle vector types`, function() {
-				assert.equal(mapParameterType('vector<string>'), 'Array<string>');
+				assert.equal(mapParameterType({ eosType: 'vector<string>' }), 'Array<string>');
 			});
 		});
 	});

--- a/src/contracts/typeGenerator.ts
+++ b/src/contracts/typeGenerator.ts
@@ -89,13 +89,7 @@ export const generateTypes = async (contractIdentifier: string) => {
 		'',
 	];
 	// Define imports
-	const imports = [
-		'Account',
-		'Contract',
-		'GetTableRowsOptions',
-		'ExtendedAsset',
-		'ExtendedSymbol',
-	];
+	const imports = ['Account', 'Contract', 'GetTableRowsOptions', 'ExtendedAsset', 'ExtendedSymbol'];
 	if (contractTables.length > 0) imports.push('TableRowsResult');
 	// Generate import definitions
 	result.push(`import { ${imports.join(', ')} } from 'lamington';`);

--- a/src/project/projectManager.ts
+++ b/src/project/projectManager.ts
@@ -33,10 +33,10 @@ const DEFAULT_SCRIPTS = {
 
 /** Required project dependencies */
 const DEFAULT_DEV_DEPENDENCIES = {
-	'lamington': 'latest',
-	'chai':'latest',
-	'@types/chai':'latest',
-	'@types/mocha':'latest'
+	lamington: 'latest',
+	chai: 'latest',
+	'@types/chai': 'latest',
+	'@types/mocha': 'latest',
 };
 
 /**
@@ -149,24 +149,29 @@ export class ProjectManager {
 				// Ensure tmp directory exists and capture directory path
 				const tmpPath = await ProjectManager.createDirectoryIfMissing('__tmp__');
 				// Stream the repo clone and untar
-				got.stream(cloneUrl).pipe(tar.extract({
-					cwd: tmpPath,
-					strip:1
-				})).on('error', (error:Error) => {
-					reject(error);
-				}).on('end', async () => {
-					// Clone example repository into tmp
-					const clonedFiles = await readdir(tmpPath);
-					if (clonedFiles.length <= 0)
-						throw new Error(`No files cloned from repo ${cloneUrl}`);
-					// Merge example contracts into current project
-					await ncp(path.join(tmpPath, 'contracts'), path.join(process.cwd(), 'contracts'));
-					// Cleanup temporary directory
-					spinner.update('Cleaning temporary files');
-					await rimraf(tmpPath);
-					spinner.end('Created example contracts');
-					resolve(true);
-				});
+				got
+					.stream(cloneUrl)
+					.pipe(
+						tar.extract({
+							cwd: tmpPath,
+							strip: 1,
+						})
+					)
+					.on('error', (error: Error) => {
+						reject(error);
+					})
+					.on('end', async () => {
+						// Clone example repository into tmp
+						const clonedFiles = await readdir(tmpPath);
+						if (clonedFiles.length <= 0) throw new Error(`No files cloned from repo ${cloneUrl}`);
+						// Merge example contracts into current project
+						await ncp(path.join(tmpPath, 'contracts'), path.join(process.cwd(), 'contracts'));
+						// Cleanup temporary directory
+						spinner.update('Cleaning temporary files');
+						await rimraf(tmpPath);
+						spinner.end('Created example contracts');
+						resolve(true);
+					});
 			});
 		} catch (error) {
 			spinner.fail('Failed to clone repository');


### PR DESCRIPTION
This extends the type generator to allow nested types in actions parameters and tables as they can be derived from the provided abi file for a contract.
The current implementation falls back to a string for non-primitive types in action parameters which opens up a potential source of bugs in created tests with the absense of type checking. 

This change populates the tables and actions parameters using not just the provided primitives but also nested structs referenced and used from the abi before finally defaulting to a string if a matching primitive and embedded struct is not found.