### PR TITLE
Adds verbose logging option for the CLI

### DIFF
--- a/src/cli/lamington-test.ts
+++ b/src/cli/lamington-test.ts
@@ -2,6 +2,8 @@ import { eosIsReady, startEos, runTests, stopContainer, buildAll } from './utils
 import { GitIgnoreManager } from '../gitignoreManager';
 import { ConfigManager } from '../configManager';
 
+export var verbose_logging: Boolean;
+
 /**
  * Executes a build and test procedure
  * @note Keep alive setup is incomplete
@@ -14,6 +16,11 @@ const run = async () => {
 	const args = process.argv;
 
 	console.log('args: ' + args);
+
+	if (args.includes('verbose')) {
+		verbose_logging = true;
+		console.log('`verbose_logging` set to `true`');
+	}
 
 	// Stop running instances for fresh test environment
 	if (await eosIsReady()) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import * as chai from 'chai';
 import * as deepEqualInAnyOrder from 'deep-equal-in-any-order';
 
 import { EOSManager } from './eosManager';
+import { verbose_logging } from './cli/lamington-test';
 import { TableRowsResult } from './contracts';
 
 // Extend Chai's expect methods
@@ -123,6 +124,9 @@ export const assertEOSError = async (
 	try {
 		await operation;
 	} catch (error) {
+		if (verbose_logging) {
+			console.log('Verbose error output: ' + JSON.stringify(error, null, 4));
+		}
 		if (error.json && error.json.error && error.json.error.name) {
 			// Compare error and fail if the error doesn't match the expected
 			assert(


### PR DESCRIPTION
When writing tests thrown errors may be difficult to identify.
This PR adds another option to get more detail for thrown errors to help identify what exception was raised to help facilitate writing a test for that exception.

To active this option the tests may run like this:

    `npm run-script test  verbose`