### PR TITLE
Fix tests in CI by allowing them to take longer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: node_js
 node_js:
   - '10'
 script:
-  - npm test
+  - travis_wait npm test
   - npm run build


### PR DESCRIPTION
Travis by default kills builds after 10 minutes. Building the docker container takes longer than this on that environment, so let's let that take longer.