### PR TITLE
chore/removed-inline-author-definitions

### DIFF
--- a/src/accounts/account.ts
+++ b/src/accounts/account.ts
@@ -49,8 +49,8 @@ export class Account {
 	}
 
 	/**
-	 * Returns a configured active key permission
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * Returns a configured active key permission.
+	 * 
 	 * @returns Valid active key
 	 */
 	public get active() {
@@ -63,8 +63,8 @@ export class Account {
 	}
 
 	/**
-	 * Returns a configured owner key permission
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * Returns a configured owner key permission.
+	 * 
 	 * @returns Valid owner key
 	 */
 	public get owner() {
@@ -77,9 +77,8 @@ export class Account {
 	}
 
 	/**
-	 * Adds the `eosio.code` permission to this account
-	 * @author Kevin Brown <github.com/thekevinbrown>
-	 * @author Mitch Pierias <github.com/MitchPierias>
+	 * Adds the `eosio.code` permission to this account.
+	 * 
 	 * @returns Add permission transaction promise
 	 */
 	public addCodePermission = async () => {

--- a/src/accounts/accountManager.ts
+++ b/src/accounts/accountManager.ts
@@ -17,12 +17,11 @@ interface AccountCreationOptions {
 
 export class AccountManager {
 	/**
-	 * Generates a new random account
-	 * @note Shorthand method for [[AccountManager.createAccounts]]
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * Generates a new random account.
+	 * 
 	 * @param accountName Optional name for the account to create
 	 * @param options Optional account creation settings
-	 * @returns Result returned from [[AccountManager.createAccounts]]
+	 * @returns Result returned from `createAccounts()`
 	 */
 	static createAccount = async (accountName?: string, options?: AccountCreationOptions) => {
 		let accountNameArray = accountName ? [accountName] : undefined;
@@ -31,8 +30,8 @@ export class AccountManager {
 	};
 
 	/**
-	 * Generates a specified number of random accounts
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * Generates a specified number of random accounts.
+	 * 
 	 * @param numberOfAccounts Number of accounts to generate
 	 * @param accountNames Array of account names. If array is provided then the numberOfAccounts is ignored.
 	 * @returns Array of created account transaction promises
@@ -66,13 +65,13 @@ export class AccountManager {
 				accounts.push(account);
 			}
 		}
-		// Return created acounts
+		// Return created accounts
 		return accounts;
 	};
 
 	/**
-	 * Publishes a new account and allocates ram where possible
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * Publishes a new account and allocates ram where possible.
+	 * 
 	 * @param account [[Account]] to publish
 	 * @param options Optional account settings
 	 * @returns Transaction result promise
@@ -176,10 +175,9 @@ export class AccountManager {
 	};
 
 	/**
-	 * Grants `eosio.code` permission to the specified account's `active` key
-	 * @note Can also be called directly on a contract.
-	 * @author Kevin Brown <github.com/thekevinbrown>
-	 * @author Mitch Pierias <github.com/MitchPierias>
+	 * Grants `eosio.code` permission to the specified account's `active` key,
+	 * where `account` is the owner of a contract.
+	 * 
 	 * @param account Account without `eosio.code` permissions
 	 */
 	public static addCodePermission = async (account: Account) => {
@@ -227,8 +225,8 @@ export class AccountManager {
 	};
 
 	/**
-	 * Flattens account creation options
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * Flattens account creation options.
+	 * 
 	 * @returns Account creation options
 	 */
 	private static flattenOptions(options?: AccountCreationOptions) {

--- a/src/accounts/utils.ts
+++ b/src/accounts/utils.ts
@@ -1,5 +1,13 @@
 import * as ecc from 'eosjs-ecc';
 
+// TODO: Extract type definitions
+export type EosioAction = {
+	account: string;
+	name: string;
+	authorization: { actor: string; permission: string }[];
+	data: any;
+};
+
 /** Digit pattern expression */
 const digitPattern = /[06789]/g;
 
@@ -13,16 +21,16 @@ const digitMapping: { [key: string]: string } = {
 };
 
 /**
- * Generates an account name from the specified public key
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Generates an account name from the specified public key.
+ * 
  * @param publicKey Valid EOSIO public key
  * @returns EOSIO account name
  */
 export const accountNameFromPublicKey = (publicKey: string) => hashToEOSName(ecc.sha256(publicKey));
 
 /**
- * Generates an account name from a hashed public key
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Generates an account name from a hashed public key.
+ * 
  * @returns EOSIO account name
  */
 export const hashToEOSName = (data: string) =>
@@ -30,10 +38,3 @@ export const hashToEOSName = (data: string) =>
 		.substring(0, 11)
 		.replace(digitPattern, (match) => digitMapping[match])
 		.toLowerCase()}`;
-
-export type EosioAction = {
-	account: string;
-	name: string;
-	authorization: { actor: string; permission: string }[];
-	data: any;
-};

--- a/src/cli/lamington-build.ts
+++ b/src/cli/lamington-build.ts
@@ -4,9 +4,8 @@ import { ConfigManager } from '../configManager';
 
 /**
  * Executes a contract build procedure
- * @note Keep alive setup is incomplete
- * @author Kevin Brown <github.com/thekevinbrown>
- * @author Mitch Pierias <github.com/MitchPierias>
+ * 
+ * TODO: Complete chain keep alive functionality
  */
 const run = async () => {
 	// Capture CLI defined contract identifiers

--- a/src/cli/lamington-init.ts
+++ b/src/cli/lamington-init.ts
@@ -4,10 +4,8 @@ import { ProjectManager } from './../project/projectManager';
 import { ConfigManager } from '../configManager';
 
 /**
- * Executes a contract build procedure
- * @note Keep alive setup is incomplete
- * @author Mitch Pierias <github.com/MitchPierias>
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Bootstraps a basic Lamington project setup ready
+ * for smart contract development.
  */
 const run = async () => {
 	await ProjectManager.initWithDefaults();

--- a/src/cli/lamington-start.ts
+++ b/src/cli/lamington-start.ts
@@ -3,8 +3,6 @@ import { ConfigManager } from '../configManager';
 
 /**
  * Stops EOS docker container if it's running, then starts it.
- * @note Keep alive setup is incomplete
- * @author Kevin Brown <github.com/thekevinbrown>
  */
 const run = async () => {
 	await ConfigManager.initWithDefaults();

--- a/src/cli/lamington-stop.ts
+++ b/src/cli/lamington-stop.ts
@@ -2,8 +2,7 @@ import { stopContainer, eosIsReady } from './utils';
 import { ConfigManager } from '../configManager';
 
 /**
- * Stops the current Lamington docker container
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Kills the current Lamington docker container.
  */
 const run = async () => {
 	await ConfigManager.initWithDefaults();

--- a/src/cli/lamington-test.ts
+++ b/src/cli/lamington-test.ts
@@ -4,10 +4,8 @@ import { ConfigManager } from '../configManager';
 import { sleep } from '../utils';
 
 /**
- * Executes a build and test procedure
- * @note Keep alive setup is incomplete
- * @author Kevin Brown <github.com/thekevinbrown>
- * @author Mitch Pierias <github.com/MitchPierias>
+ * Starts an EOSIO docker container if none is found,
+ * and executes a smart contract build and test flow.
  */
 const run = async () => {
 	// Initialize the configuration

--- a/src/cli/logIndicator.ts
+++ b/src/cli/logIndicator.ts
@@ -5,8 +5,8 @@ import * as colors from 'colors';
 const cache: { spinner?: ora.Ora } = {};
 
 /**
- * Creates a new spinner instance with the specified message
- * @author Mitch Pierias <github.com/MitchPierias>
+ * Creates a new spinner instance with the specified message.
+ * 
  * @param text Output display message
  */
 export const create = (text: string) => {
@@ -20,8 +20,8 @@ export const create = (text: string) => {
 };
 
 /**
- * Updates the text of the current spinner
- * @author Mitch Pierias <github.com/MitchPierias>
+ * Updates the text of the current spinner.
+ * 
  * @param text CLI output text to display
  */
 export const update = (text: string) => {
@@ -36,8 +36,8 @@ export const update = (text: string) => {
 };
 
 /**
- * Terminates the current spinner with the specified output message
- * @author Mitch Pierias <github.com/MitchPierias>
+ * Terminates the current spinner with the specified output message.
+ * 
  * @param message Output message
  * @param isError Renders output as error toggle
  */
@@ -55,8 +55,8 @@ export const end = (message: string = '', isError: boolean = false) => {
 };
 
 /**
- * Terminates the current spinner as an error with output message
- * @author Mitch Pierias <github.com/MitchPierias>
+ * Terminates the current spinner as an error with output message.
+ * 
  * @param message Spinner message.
  */
 export const fail = (message: string) => {

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -49,8 +49,8 @@ const TEST_TIMEOUT_DURATION = 80000;
 const MAX_CONNECTION_ATTEMPTS = 20;
 
 /**
- * Extracts the version identifier from a string
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Extracts the version identifier from a string.
+ * 
  * @returns Version identifier
  */
 const versionFromUrl = (url: string) => {
@@ -64,9 +64,8 @@ const versionFromUrl = (url: string) => {
 };
 
 /**
- * Constructs the name of the current Lamington Docker image
- * @author Kevin Brown <github.com/thekevinbrown>
- * @author Johan Nordberg <github.com/jnordberg>
+ * Constructs the name of the current Lamington Docker image.
+ * 
  * @returns Docker image name
  */
 const dockerImageName = async () => {
@@ -78,8 +77,8 @@ const dockerImageName = async () => {
 };
 
 /**
- * Determines if the docker image exists
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Determines if the docker image exists.
+ * 
  * @returns Result of search
  */
 export const imageExists = async () => {
@@ -89,10 +88,8 @@ export const imageExists = async () => {
 };
 
 /**
- * Configures and builds the docker image
- * @author Kevin Brown <github.com/thekevinbrown>
- * @author Mitch Pierias <github.com/MitchPierias>
- * @author Johan Nordberg <github.com/jnordberg>
+ * Configures and builds the docker image.
+ * 
  */
 export const buildImage = async () => {
 	// Log notification
@@ -128,8 +125,7 @@ export const buildImage = async () => {
 };
 
 /**
- * Starts the Lamington container
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Starts the Lamington Docker container.
  */
 export const startContainer = async () => {
 	await docker.command(
@@ -151,9 +147,8 @@ export const startContainer = async () => {
 };
 
 /**
- * Stops the current Lamington container
- * @author Kevin Brown <github.com/thekevinbrown>
- * @author Mitch Pierias <github.com/MitchPierias>
+ * Stops the current Lamington container.
+ * 
  * @returns Docker command promise
  */
 export const stopContainer = async () => {
@@ -168,9 +163,8 @@ export const stopContainer = async () => {
 };
 
 /**
- * Sleeps the process until the EOS instance is available
- * @author Kevin Brown <github.com/thekevinbrown>
- * @author Mitch Pierias <github.com/MitchPierias>
+ * Sleeps the process until the EOS instance is available.
+ * 
  * @returns Connection success or throws error
  */
 export const untilEosIsReady = async (attempts: number = MAX_CONNECTION_ATTEMPTS) => {
@@ -194,8 +188,8 @@ export const untilEosIsReady = async (attempts: number = MAX_CONNECTION_ATTEMPTS
 };
 
 /**
- * Determines if EOS is available using the `get_info` query response
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Determines if EOS is available using the `get_info` query response.
+ * 
  * @returns EOS instance availability
  */
 export const eosIsReady = async () => {
@@ -209,9 +203,8 @@ export const eosIsReady = async () => {
 
 /**
  * Pulls the EOSIO docker image if it doesn't exist and starts
- * a new EOSIO docker container
- * @author Kevin Brown <github.com/thekevinbrown>
- * @author Mitch Pierias <github.com/MitchPierias>
+ * a new EOSIO docker container.
+ * 
  */
 export const startEos = async () => {
 	spinner.create('Starting EOS docker container');
@@ -255,8 +248,8 @@ export const startEos = async () => {
 };
 
 /**
- * Loads all test files and executes with Mocha
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Loads all test files and executes with Mocha.
+ * 
  * @note This is where we should allow configuration over all files or specified files/folder
  */
 export const runTests = async () => {
@@ -306,9 +299,8 @@ export const runTests = async () => {
 };
 
 /**
- * Finds and builds all C++ contracts
- * @author Kevin Brown <github.com/thekevinbrown>
- * @author Mitch Pierias <github.com/MitchPierias>
+ * Finds and builds all C++ contracts.
+ * 
  * @param match Optional specific contract identifiers to build
  */
 export const buildAll = async (match?: string[]) => {
@@ -378,8 +370,8 @@ const filterMatches = (paths: string[]) => {
 
 /**
  * Resolves the path to file identifier.
- * This is the path without trailing file extension
- * @author Kevin Brown <github.com/thekevinbrown>
+ * This is the path without trailing file extension.
+ * 
  * @note What happens when the input path contains no trailing extension?
  * @param filePath Path to file
  * @returns Identifier path
@@ -387,9 +379,8 @@ const filterMatches = (paths: string[]) => {
 export const pathToIdentifier = (filePath: string) => filePath.substr(0, filePath.lastIndexOf('.'));
 
 /**
- * Builds contract resources for contract at path
- * @author Kevin Brown <github.com/thekevinbrown>
- * @author Mitch Pierias <github.com/MitchPierias>
+ * Builds contract resources for contract at path.
+ * 
  * @param contractPath Local path to C++ contract file
  */
 export const build = async (contractPath: string) => {
@@ -409,8 +400,8 @@ export const build = async (contractPath: string) => {
 };
 
 /**
- * Determines the output location for a contract based on the full path of its C++ file.
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Determines the output location for a contract based on the full path of its C++ file..
+ * 
  * @param contractPath Full path to C++ contract file
  * @returns Output path for contract compilation artefacts
  */
@@ -418,9 +409,8 @@ export const outputPathForContract = (contractPath: string) =>
 	path.join(ConfigManager.outDir, 'compiled_contracts', path.dirname(contractPath));
 
 /**
- * Compiles a C++ EOSIO smart contract at path
- * @author Kevin Brown <github.com/thekevinbrown>
- * @author Mitch Pierias <github.com/MitchPierias>
+ * Compiles a C++ EOSIO smart contract at path.
+ * 
  * @param contractPath Full path to C++ contract file
  */
 export const compileContract = async (contractPath: string) => {

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -21,7 +21,11 @@ const ENCODING = 'utf8';
 /** @hidden Configuration file name */
 const CONFIGURATION_FILE_NAME = '.lamingtonrc';
 
-/** @hidden Configuration object structure */
+/**
+ * @hidden Configuration object structure
+ * 
+ * TODO: Extract type definitions amd create BaseConfig
+ */
 export interface LamingtonConfig {
 	cdt: string;
 	eos: string;
@@ -39,6 +43,8 @@ export interface LamingtonConfig {
 
 /**
  * Level of debug output
+ * 
+ * TODO: Extract type definitions
  */
 export enum LamingtonDebugLevel {
 	NONE = 0, // No debug logging
@@ -65,7 +71,7 @@ export namespace LamingtonDebugLevel {
  * as the base layer config. Users can override these
  * values by specifying them in their `.lamingtonrc`
  */
-const DEFAULT_CONFIG = {
+const DEFAULT_CONFIG:LamingtonConfig = {
 	eos: '',
 	cdt: '',
 	contracts: 'v1.8.0-rc1',
@@ -87,9 +93,7 @@ export class ConfigManager {
 
 	/**
 	 * Initialize application configuration using the user
-	 * defined configurations and defaults
-	 * @author Kevin Brown <github.com/thekevinbrown>
-	 * @author Mitch Pierias <github.com/MitchPierias>
+	 * defined configurations and defaults.
 	 */
 	public static async initWithDefaults() {
 		DEFAULT_CONFIG.cdt = await ConfigManager.getAssetURL('EOSIO', 'eosio.cdt', 'amd64.deb');
@@ -107,8 +111,7 @@ export class ConfigManager {
 
 	/**
 	 * Downloads the organization's latest repository release image and
-	 * returns the assets matching the specified filter
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * returns the assets matching the specified filter.
 	 * @param organization Asset's case-sensitive repository organization
 	 * @param repository Asset's case-sensitive repository name
 	 * @param filter Resource filter
@@ -143,8 +146,6 @@ export class ConfigManager {
 
 	/**
 	 * Creates a default configuration file if it doesn't exist at the specified path.
-	 * @author Mitch Pierias <github.com/MitchPierias>
-	 * @author Kevin Brown <github.com/thekevinbrown>
 	 * @param atPath Optional configuration file path. Defaults to `.lamingtonrc`.
 	 */
 	public static async createConfigIfMissing(atPath = CONFIGURATION_FILE_NAME) {
@@ -167,10 +168,8 @@ export class ConfigManager {
 	}
 
 	/**
-	 * Checks the existence of the configuration
-	 * file at the default [[CONFIGURATION_FILE_NAME]] or
-	 * optional path
-	 * @author Mitch Pierias <github.com/MitchPierias>
+	 * Checks the existence of the configuration file at the
+	 * default [[CONFIGURATION_FILE_NAME]] or optional path.
 	 * @param atPath Optional file path for lookup
 	 * @returns Config exists determiner
 	 */
@@ -181,8 +180,7 @@ export class ConfigManager {
 	}
 
 	/**
-	 * Loads an existing configuration file into [[ConfigManager.config]]
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * Loads an existing configuration file into the `config` state.
 	 * @param atPath Optional file path for lookup
 	 */
 	public static async loadConfigFromDisk(atPath = CONFIGURATION_FILE_NAME) {
@@ -194,40 +192,35 @@ export class ConfigManager {
 	}
 
 	/**
-	 * Returns the current EOSIO configuration
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * Returns the current EOSIO configuration.
 	 */
 	static get eos() {
 		return (ConfigManager.config && ConfigManager.config.eos) || '';
 	}
 
 	/**
-	 * Returns the current EOSIO.CDT configuration
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * Returns the current EOSIO.CDT configuration.
 	 */
 	static get cdt() {
 		return (ConfigManager.config && ConfigManager.config.cdt) || '';
 	}
 
 	/**
-	 * Returns the current eosio.contracts configuration
-	 * @author Johan Nordberg <github.com/jnordberg>
+	 * Returns the current eosio.contracts configuration.
 	 */
 	static get contracts() {
 		return (ConfigManager.config && ConfigManager.config.contracts) || 'master';
 	}
 
 	/**
-	 * Returns the container keep alive setting or false
-	 * @author Mitch Pierias <github.com/MitchPierias>
+	 * Returns the container keep alive setting or `false`.
 	 */
 	static get keepAlive() {
 		return (ConfigManager.config && ConfigManager.config.keepAlive) || DEFAULT_CONFIG.keepAlive;
 	}
 
 	/**
-	 * Returns the container's debug log output setting
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * Returns the container's debug log output setting.
 	 */
 	static get debugTransactions() {
 		return (
@@ -237,16 +230,14 @@ export class ConfigManager {
 	}
 
 	/**
-	 * Returns the container's debugLevel output setting
-	 * @author Dallas Johnson <github.com/dallasjohnson>
+	 * Returns the container's `debugLevel` output setting.
 	 */
 	static get debugLevel() {
 		return (ConfigManager.config && ConfigManager.config.debug) || DEFAULT_CONFIG.debug;
 	}
 
 	/**
-	 * Returns the container's debugLevel output setting
-	 * @author Dallas Johnson <github.com/dallasjohnson>
+	 * Returns the container's `debugLevel` output setting
 	 */
 	static get debugLevelNone() {
 		return LamingtonDebugLevel.isNone(this.debugLevel);
@@ -261,40 +252,36 @@ export class ConfigManager {
 	}
 
 	/**
-	 * Returns the output build directory or [[CACHE_DIRECTORY]]
-	 * @author Mitch Pierias <github.com/MitchPierias>
+	 * Returns the output build directory or the default `CACHE_DIRECTORY`.
 	 */
 	static get outDir() {
 		return (ConfigManager.config && ConfigManager.config.outDir) || DEFAULT_CONFIG.outDir;
 	}
 
 	/**
-	 * Returns the array of included strings or patterns. Defaults to include all `*.cpp` files
-	 * @author Dallas Johnson <github.com/dallasjohnson>
+	 * Returns the array of included strings or patterns. Defaults to
+	 * include all `*.cpp` files.
 	 */
 	static get include() {
 		return (ConfigManager.config && ConfigManager.config.include) || DEFAULT_CONFIG.include;
 	}
 
 	/**
-	 * Returns the array of excluded strings or patterns
-	 * @author Mitch Pierias <github.com/MitchPierias>
+	 * Returns the array of excluded strings or patterns.
 	 */
 	static get exclude() {
 		return (ConfigManager.config && ConfigManager.config.exclude) || DEFAULT_CONFIG.exclude;
 	}
 
 	/**
-	 * Returns the array of excluded strings or patterns
-	 * @author Dallas Johnson <github.com/dallasjohnson>
+	 * Returns the array of excluded strings or patterns.
 	 */
 	static get testReporter() {
 		return (ConfigManager.config && ConfigManager.config.reporter) || Mocha.reporters.Min;
 	}
 
 	/**
-	 * Returns the array of excluded strings or patterns
-	 * @author Dallas Johnson <github.com/dallasjohnson>
+	 * Returns the array of excluded strings or patterns.
 	 */
 	static get bailOnFailure() {
 		return (

--- a/src/contracts/contract.ts
+++ b/src/contracts/contract.ts
@@ -60,8 +60,8 @@ export class Contract implements EOSJSContract {
 	public types: Map<string, Type> = new Map();
 
 	/**
-	 * Gets the currently configured contract account
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * Gets the currently configured contract account.
+	 * 
 	 * @returns Current contract account
 	 */
 	public get account() {
@@ -69,8 +69,8 @@ export class Contract implements EOSJSContract {
 	}
 
 	/**
-	 * Gets the current contract identifier
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * Gets the current contract identifier.
+	 * 
 	 * @returns Contract identifier
 	 */
 	public get identifier() {
@@ -148,8 +148,8 @@ export class Contract implements EOSJSContract {
 	}
 
 	/**
-	 * Retrieves table rows with the specified table name and optional scope
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * Retrieves table rows with the specified table name and optional scope.
+	 * 
 	 * @note Implements a temporary patch for the EOSjs `bool` mapping error
 	 * @param table The table name
 	 * @param scope Optional table scope, defaults to the table name
@@ -233,10 +233,9 @@ export class Contract implements EOSJSContract {
 	};
 
 	/**
-	 * Grants `eosio.code` permission to the contract account's `active` key
-	 * @note Can also be called from AccountManager, as the action is technically an account based action.
-	 * @author Kevin Brown <github.com/thekevinbrown>
-	 * @author Mitch Pierias <github.com/MitchPierias>
+	 * Grants `eosio.code` permission to the contract account's `active` key by
+	 * calling the `addCodePermission` of `AccountManager` with the current
+	 * `account` state.
 	 */
 	public addCodePermission = () => AccountManager.addCodePermission(this._account);
 }

--- a/src/contracts/contractDeployer.ts
+++ b/src/contracts/contractDeployer.ts
@@ -1,32 +1,33 @@
 import * as path from 'path';
-import { readFile as readFileCallback, exists as existsCallback } from 'fs';
+import { readFile as readFileCallback, existypescript as existypescriptCallback } from 'fs';
 import { promisify } from 'util';
 import { Serialize } from 'eosjs';
 import * as ecc from 'eosjs-ecc';
 
-const exists = promisify(existsCallback);
+const existypescript = promisify(existypescriptCallback);
 const readFile = promisify(readFileCallback);
 
 import { Contract } from './contract';
-import { Account, AccountManager } from '../accounts';
+import { Account, AccountManager } from '../accountypescript';
 import { EOSManager } from '../eosManager';
 import { ConfigManager } from '../configManager';
 import { ContractLoader } from './contractLoader';
 
 /**
- * Provides a set of methods to manage contract deployment
+ * Provides a set of methods to manage contract deployment.
  */
 export class ContractDeployer {
 	/**
 	 * Deploys contract files to a specified account
 	 *
+	 * @example
 	 * ```typescript
 	 * // Create a new account
 	 * const account = await AccountManager.createAccount();
 	 * // Deploy the contract `mycontract` to the account
 	 * ContractDeployer.deployToAccount<MyContractTypeDef>('mycontract', account);
 	 * ```
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * 
 	 * @param contractIdentifier Contract identifier, typically the contract filename minus the extension
 	 * @param account Account to apply contract code
 	 * @returns Deployed contract instance
@@ -45,11 +46,11 @@ export class ContractDeployer {
 		// Construct resource paths
 		const abiPath = path.join(
 			ConfigManager.outDir,
-			'compiled_contracts',
+			'compiled_contractypescript',
 			`${contractIdentifier}.abi`
 		);
 
-		if (!(await exists(abiPath))) {
+		if (!(await existypescript(abiPath))) {
 			throw new Error(
 				`Couldn't find ABI at ${abiPath}. Are you sure you used the correct contract identifier?`
 			);
@@ -57,11 +58,11 @@ export class ContractDeployer {
 
 		const wasmPath = path.join(
 			ConfigManager.outDir,
-			'compiled_contracts',
+			'compiled_contractypescript',
 			`${contractIdentifier}.wasm`
 		);
 
-		if (!(await exists(wasmPath))) {
+		if (!(await existypescript(wasmPath))) {
 			throw new Error(
 				`Couldn't find WASM file at ${wasmPath}. Are you sure you used the correct contract identifier?`
 			);
@@ -112,14 +113,14 @@ export class ContractDeployer {
 	}
 
 	/**
-	 * Deploys contract files to a randomly generated account
+	 * Deploys contract files to a randomly generated account.
 	 *
+	 * @example
 	 * ```typescript
 	 * // Deploy the contract with identifier
 	 * ContractDeployer.deploy<MyContractTypeDef>('mycontract');
 	 * ```
-	 *
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * 
 	 * @param contractIdentifier Contract identifier, typically the contract filename minus the extension
 	 * @returns Deployed contract instance
 	 */
@@ -131,15 +132,15 @@ export class ContractDeployer {
 	}
 
 	/**
-	 * Deploys contract files to a specified account name
+	 * Deploys contract files to a specified account name.
 	 *
+	 * @example
 	 * ```typescript
 	 * // Deploy the `mycontract` contract to the account with name `mycontractname`
 	 * ContractDeployer.deployWithName<MyContractTypeDef>('mycontract', 'mycontractname');
 	 * ```
 	 *
 	 * @note Generating a pseudorandom private key is not safe in the cryptographic sense. It can be used for testing.
-	 * @author Mitch Pierias <github.com/MitchPierias>
 	 * @param contractIdentifier Contract identifier, typically the contract filename minus the extension
 	 * @param accountName Account name
 	 * @returns Deployed contract instance

--- a/src/contracts/contractLoader.ts
+++ b/src/contracts/contractLoader.ts
@@ -16,7 +16,7 @@ export class ContractLoader {
 	 *
 	 * ContractLoader.at<MyContractTypeDef>('my.contract');
 	 * ```
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * 
 	 * @param accountOrName The account or account name where the contract is already deployed.
 	 * @returns Contract instance
 	 */

--- a/src/contracts/typeGenerator.ts
+++ b/src/contracts/typeGenerator.ts
@@ -12,9 +12,8 @@ type IndentedGeneratorLevel = { [key: string]: Array<string> | IndentedGenerator
 type GeneratorLevel = Array<string | IndentedGeneratorLevel>;
 
 /**
- * Parses a C++ type definition into a Typescript definition
- * @author Kevin Brown <github.com/thekevinbrown>
- * @author Mitch Pierias <github.com/MitchPierias>
+ * Parses a C++ type definition into a Typescript definition.
+ * 
  * @param eosType The type from the ABI we want to map over to a Typescript type
  * @param contractName (optional) The name of the contract to prefix the mapped type with if this is a contract struct type
  * @param contractStructs (optional) Structs in the contract used to match against, falling back to built in types if not found
@@ -42,6 +41,7 @@ export const mapParameterType = ({
 	}
 };
 
+// TODO: Document method
 export const generateTypesFromString = async (
 	rawABI: string,
 	contractName: string
@@ -134,8 +134,7 @@ export const generateTypesFromString = async (
 };
 
 /**
- * Loads all `.abi` files and generates types
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Loads all `.abi` files and generates types.
  */
 export const generateAllTypes = async () => {
 	// Load all `.abi` files
@@ -147,11 +146,8 @@ export const generateAllTypes = async () => {
 };
 
 /**
- * Generates a Typescript definition file from a contract ABI file
- * @author Kevin Brown <github.com/thekevinbrown>
- * @author Mitch Pierias <github.com/MitchPierias>
- * @author Dallas Johnson <github.com/dallasjohnson>
-
+ * Generates a Typescript definition file from a contract ABI file.
+ * 
  * @param contractIdentifier Path to file without extension
  */
 export const generateTypes = async (contractIdentifier: string) => {
@@ -171,6 +167,7 @@ export const generateTypes = async (contractIdentifier: string) => {
 	await saveInterface(contractIdentifier, generaterLevels);
 };
 
+// TODO: Document method
 const flattenGeneratorLevels = (interfaceContent: GeneratorLevel): string => {
 	let result = '';
 	let indentLevel = 0;
@@ -206,9 +203,8 @@ const flattenGeneratorLevels = (interfaceContent: GeneratorLevel): string => {
 };
 
 /**
- * Writes the contract interface to file
- * @author Kevin Brown <github.com/thekevinbrown>
- * @author Dallas Johnson <github.com/dallasjohnson>
+ * Writes the contract interface to file.
+ * 
  * @param contractIdentifier Path to file without extension
  * @param interfaceContent Generated contract interface as a string
  */
@@ -221,5 +217,6 @@ const saveInterface = async (contractIdentifier: string, interfaceContent: strin
 			throw error;
 		}
 	});
+	
 	file.close();
 };

--- a/src/contracts/utils.ts
+++ b/src/contracts/utils.ts
@@ -1,7 +1,7 @@
 /**
  * Transforms a string into the pascal-case format.
  * ThisIsPascalCase, while thisIsCamelCase, this-is-kebab-case, and this_is_snake_case.
- * @author Kevin Brown <github.com/thekevinbrown>
+ * 
  * @param value String for case transformation
  */
 export const pascalCase = (value: string) => {
@@ -13,7 +13,7 @@ export const pascalCase = (value: string) => {
 /**
  * Transforms a string into the camel-case format.
  * ThisIsPascalCase, while thisIsCamelCase, this-is-kebab-case, and this_is_snake_case.
- * @author Kevin Brown <github.com/thekevinbrown>
+ * 
  * @param value String for case transformation
  */
 export const camelCase = (value: string) => {

--- a/src/eosManager.ts
+++ b/src/eosManager.ts
@@ -30,7 +30,6 @@ export class EOSManager {
 	/**
 	 * Initializes a default connection to the local EOSIO node on port `8888` and
 	 * assigns the default `eosio` account with administration keys
-	 * @author Kevin Brown <github.com/thekevinbrown>
 	 */
 	static initWithDefaults = () => {
 		// Create eosio account and configure signature provider
@@ -46,7 +45,6 @@ export class EOSManager {
 	/**
 	 * Initializes a connection to any EOSIO node and sets the administration keys which
 	 * Lamington uses to deploy contracts, create accounts, etc.
-	 * @author Kevin Brown <github.com/thekevinbrown>
 	 */
 	static init = ({ httpEndpoint, adminAccount, chainId }: InitArgs) => {
 		// Create eosio account and configure signature provider
@@ -72,7 +70,7 @@ export class EOSManager {
 
 	/**
 	 * Ensures our signature provider has the key in question, and if not, adds it.
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * 
 	 * @param account Account to be unioned into the signature list.
 	 */
 	static addSigningAccountIfMissing = (account: Account) => {
@@ -89,7 +87,7 @@ export class EOSManager {
 
 	/**
 	 * Executes a transaction against a connected EOSjs client
-	 * @author Kevin Brown <github.com/thekevinbrown>
+	 * 
 	 * @param transaction EOSIO transaction object
 	 * @param eos Connected EOSjs client
 	 * @param options Additional transaction options

--- a/src/project/projectManager.ts
+++ b/src/project/projectManager.ts
@@ -41,7 +41,6 @@ const DEFAULT_DEV_DEPENDENCIES = {
 
 /**
  * Fetches and stores the latest EOS configuration images
- * @author Mitch Pierias <github.com/MitchPierias>
  */
 export class ProjectManager {
 	/** @hidden Reference to the local `package.json` file */
@@ -52,7 +51,6 @@ export class ProjectManager {
 
 	/**
 	 * Downloads the example project and integrates aspects where required.
-	 * @author Mitch Pierias <github.com/MitchPierias>
 	 */
 	public static async initWithDefaults() {
 		await ProjectManager.cloneExampleProject();
@@ -79,7 +77,6 @@ export class ProjectManager {
 	/**
 	 * Examines the current directory and loads any existing `package.json` file
 	 * into this object cache state.
-	 * @author Mitch Pierias <github.com/MitchPierias>
 	 * @hidden
 	 */
 	private static async loadExistingProject() {
@@ -103,7 +100,6 @@ export class ProjectManager {
 
 	/**
 	 * Injects recommended Lamington scripts into the currently cached package data
-	 * @author Mitch Pierias <github.com/MitchPierias>
 	 * @hidden
 	 */
 	private static async injectScripts() {
@@ -115,7 +111,6 @@ export class ProjectManager {
 
 	/**
 	 * Injects the required project dependencies into the currently cached package data
-	 * @author Mitch Pierias <github.com/MitchPierias>
 	 * @hidden
 	 */
 	private static async configureDependencies() {
@@ -127,7 +122,6 @@ export class ProjectManager {
 
 	/**
 	 * Downloads the latest example Lamington project from GitHub
-	 * @author Mitch Pierias <github.com/MitchPierias>
 	 * @hidden
 	 */
 	private static async cloneExampleProject() {
@@ -181,7 +175,6 @@ export class ProjectManager {
 
 	/**
 	 * Creates a new local directory if missing and returns the path
-	 * @author Mitch Pierias <github.com/MitchPierias>
 	 * @param dirName Directory to create
 	 * @returns Path to local directory
 	 * @private

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,9 +12,9 @@ import * as chalk from 'chalk';
 chai.use(deepEqualInAnyOrder);
 
 /**
- * Pauses the current process until the specified EOS block number occurs
+ * Pauses the current process until the specified EOS block number occurs.
+ * 
  * @note Assumes blocks will always be produced every 500ms
- * @author Kevin Brown <github.com/thekevinbrown>
  * @param number Process sleep duration
  */
 export const untilBlocknumber = async (number: number) => {
@@ -28,23 +28,23 @@ export const untilBlocknumber = async (number: number) => {
 };
 
 /**
- * Pauses the current process for the specified duration
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Pauses the current process for the specified duration.
+ * 
  * @param delayInMs Process sleep duration
  */
 export const sleep = async (delayInMs: number) =>
 	new Promise((resolve) => setTimeout(resolve, delayInMs));
 
 /**
- * Pauses the current process for the 500ms EOS block time
+ * Pauses the current process for the 500ms EOS block time.
+ * 
  * @note The process will wake during and not on the next block
- * @author Kevin Brown <github.com/thekevinbrown>
  */
 export const nextBlock = () => sleep(500);
 
 /**
- * Compares table rows against expected rows irrespective of order
- * @author Dallas Johnson <github.com/dallasjohnson>
+ * Compares table rows against expected rows irrespective of order.
+ * 
  * @param getTableRowsResult Get table rows result promise
  * @param expected Expected table row query results
  */
@@ -66,9 +66,8 @@ export const assertRowsContain = async <RowType>(
 };
 
 /**
- * Compares table rows against expected rows irrespective of order
- * @author Kevin Brown <github.com/thekevinbrown>
- * @author Mitch Pierias <github.com/MitchPierias>
+ * Compares table rows against expected rows irrespective of order.
+ * 
  * @param getTableRowsResult Get table rows result promise
  * @param expected Expected table row query results
  * @param strict Strict comparison flag
@@ -93,8 +92,8 @@ export const assertRowsEqual = async <RowType>(
 };
 
 /**
- * Performs a strict comparison of queried table rows against expected rows
- * @author Mitch Pierias <github.com/MitchPierias>
+ * Performs a strict comparison of queried table rows against expected rows.
+ * 
  * @param getTableRowsResult Get table rows result promise
  * @param expected Expected table row query results
  */
@@ -112,8 +111,8 @@ export const assertRowsEqualStrict = async <RowType>(
 };
 
 /**
- * Validates the number of rows returned is equal to the expected count
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Validates the number of rows returned is equal to the expected count.
+ * 
  * @param getTableRowsResult Get table rows result promise
  * @param expectedRowCount Expected number of table rows
  */
@@ -135,9 +134,7 @@ export const assertRowCount = async (
 /**
  * Asserts EOS throws an error and validates the error output name matches the expected `eosErrorName`
  * Also asserts that other aspects of the error as checked through an optional passed in function.
- * @author Dallas Johnson <github.com/dallasjohnson>
- * @author Kevin Brown <github.com/thekevinbrown>
- * @author Mitch Pierias <github.com/MitchPierias>
+ * 
  * @param operation Operation promise
  * @param eosErrorName Expected EOS error name
  * @param description Output message description
@@ -174,8 +171,8 @@ const assertExpectedEOSError = async (
 };
 
 /**
- * Asserts EOS throws an error and validates the error output name matches the expected `eosErrorName`
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Asserts EOS throws an error and validates the error output name matches the expected `eosErrorName`.
+ * 
  * @param operation Operation promise
  * @param eosErrorName Expected EOS error name
  * @param description Output message description
@@ -193,8 +190,8 @@ export const assertEOSError = async (
 
 /**
  * Asserts EOS throws an error and validates the error output name matches the
- * expected 'eosio_assert_message_exception' and the error message includes `description`
- * @author Dallas Johnson <github.com/dallasjohnson>
+ * expected 'eosio_assert_message_exception' and the error message includes `description`.
+ * 
  * @param operation Operation promise
  * @param message Output message expected to be included
  */
@@ -228,16 +225,16 @@ export const assertEOSErrorIncludesMessage = async (
 };
 
 /**
- * Asserts operation throws an `eosio_assert_message_exception` error
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Asserts operation throws an `eosio_assert_message_exception` error.
+ * 
  * @param operation Operation promise
  */
 export const assertEOSException = async (operation: Promise<any>) =>
 	assertEOSError(operation, 'eosio_assert_message_exception', 'assert');
 
 /**
- * Asserts operation is missing the required authority by throwing a `missing_auth_exception` error
- * @author Kevin Brown <github.com/thekevinbrown>
+ * Asserts operation is missing the required authority by throwing a `missing_auth_exception` error.
+ * 
  * @param operation Operation promise
  */
 export const assertMissingAuthority = async (operation: Promise<any>) =>


### PR DESCRIPTION
### Removed inline author definitions

Removed the `@author` definitions from comment blocks as they are automatically captured in the git history, and can be exposed via tools such as `GitLens` or document generating frameworks.